### PR TITLE
Log when we have to wait to queue a message

### DIFF
--- a/lib/nostrum/api/ratelimiter.ex
+++ b/lib/nostrum/api/ratelimiter.ex
@@ -69,6 +69,8 @@ defmodule Nostrum.Api.Ratelimiter do
         GenServer.reply(original_from || from, do_request(request, conn))
 
       time ->
+        Logger.warning("We have to wait to send #{inspect(self())}")
+
         Task.start(fn ->
           wait_for_timeout(request, time, original_from || from)
         end)


### PR DESCRIPTION
Log our object when we have to wait to queue a message